### PR TITLE
EnderContainers 2.2.2

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>fr.utarwyn</groupId>
         <artifactId>endercontainers</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
     </parent>
 
     <artifactId>endercontainers-api</artifactId>

--- a/dependencies/Factions1/pom.xml
+++ b/dependencies/Factions1/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>fr.utarwyn</groupId>
         <artifactId>endercontainers</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>endercontainers-api</artifactId>
-            <version>2.2.1</version>
+            <version>2.2.2</version>
         </dependency>
         <dependency>
             <groupId>com.massivecraft</groupId>

--- a/dependencies/Factions2/pom.xml
+++ b/dependencies/Factions2/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>fr.utarwyn</groupId>
         <artifactId>endercontainers</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>endercontainers-api</artifactId>
-            <version>2.2.1</version>
+            <version>2.2.2</version>
         </dependency>
         <dependency>
             <groupId>com.massivecraft</groupId>

--- a/dependencies/PlotSquared/pom.xml
+++ b/dependencies/PlotSquared/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>fr.utarwyn</groupId>
         <artifactId>endercontainers</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>endercontainers-api</artifactId>
-            <version>2.2.1</version>
+            <version>2.2.2</version>
         </dependency>
         <dependency>
             <groupId>com.plotsquared</groupId>

--- a/dependencies/WorldGuard6/pom.xml
+++ b/dependencies/WorldGuard6/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>fr.utarwyn</groupId>
         <artifactId>endercontainers</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>endercontainers-api</artifactId>
-            <version>2.2.1</version>
+            <version>2.2.2</version>
         </dependency>
 
         <dependency>

--- a/dependencies/WorldGuard7/pom.xml
+++ b/dependencies/WorldGuard7/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>fr.utarwyn</groupId>
         <artifactId>endercontainers</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>endercontainers-api</artifactId>
-            <version>2.2.1</version>
+            <version>2.2.2</version>
         </dependency>
         <dependency>
             <groupId>com.sk89q.worldguard</groupId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>fr.utarwyn</groupId>
         <artifactId>endercontainers</artifactId>
-        <version>2.2.1</version>
+        <version>2.2.2</version>
     </parent>
 
     <artifactId>endercontainers-plugin</artifactId>
@@ -23,37 +23,37 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>endercontainers-api</artifactId>
-            <version>2.2.1</version>
+            <version>2.2.2</version>
         </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>endercontainers-dependency-factions1</artifactId>
-            <version>2.2.1</version>
+            <version>2.2.2</version>
         </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>endercontainers-dependency-factions2</artifactId>
-            <version>2.2.1</version>
+            <version>2.2.2</version>
         </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>endercontainers-dependency-plotsquared</artifactId>
-            <version>2.2.1</version>
+            <version>2.2.2</version>
         </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>endercontainers-dependency-worldguard6</artifactId>
-            <version>2.2.1</version>
+            <version>2.2.2</version>
         </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>endercontainers-dependency-worldguard7</artifactId>
-            <version>2.2.1</version>
+            <version>2.2.2</version>
         </dependency>
 
         <dependency>

--- a/plugin/src/main/resources/config.yml
+++ b/plugin/src/main/resources/config.yml
@@ -1,6 +1,6 @@
 # # # # # # # # # # # # # # # # # # # # #
 #   EnderContainers configuration       #
-#   Version: 2.2.1                      #
+#   Version: 2.2.2                      #
 #   An enderchests plugin by Utarwyn    #
 # # # # # # # # # # # # # # # # # # # # #
 

--- a/plugin/src/main/resources/locales/en.yml
+++ b/plugin/src/main/resources/locales/en.yml
@@ -1,6 +1,6 @@
 # # # # # # # # # # # # # # # # # # # # # #
 #   EnderContainers english locale        #
-#   Version: 2.2.1                        #
+#   Version: 2.2.2                        #
 #   An enderchests plugin by Utarwyn      #
 # # # # # # # # # # # # # # # # # # # # # #
 

--- a/plugin/src/main/resources/plugin.yml
+++ b/plugin/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: EnderContainers
 author: Utarwyn
-version: 2.2.1
+version: 2.2.2
 main: fr.utarwyn.endercontainers.EnderContainers
 api-version: "1.13"
 softdepend: [Factions, PlotSquared, Essentials, WorldGuard]

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <bukkit-api.version>1.17-R0.1-SNAPSHOT</bukkit-api.version>
+        <bukkit-api.version>1.17.1-R0.1-SNAPSHOT</bukkit-api.version>
         <junit.version>4.13.1</junit.version>
         <mockito.version>3.8.0</mockito.version>
         <assertj.version>3.19.0</assertj.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>fr.utarwyn</groupId>
     <artifactId>endercontainers</artifactId>
-    <version>2.2.1</version>
+    <version>2.2.2</version>
     <packaging>pom</packaging>
 
     <name>EnderContainers</name>


### PR DESCRIPTION
> Hover commit numbers to see changes details!
> You need to migrate from **2.1.x**? Follow [this link](https://github.com/utarwyn/EnderContainers/wiki/From-2.1.x-to-2.2.x) to get all details.

### What's new?

* GH-152: Add support of Minecraft 1.17 [ff62f63][bd59ba2]

### What's fixed?

* GH-158: Fix duplication issues with large enderchests [5e96988]
* GH-136: Fix offline player enderchest opening in newest Minecraft versions [45392a2]
* GH-130: Fix commands disabled when reloading plugin while using EssentialsX [e2b475e]
* Do not throw exception without chests in the database table [731f2ce]
