### PR TITLE
Support Minecraft 1.18

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,11 +19,13 @@ pipeline {
         }
 
         stage('Deploy') {
-            steps {
-                withMaven(options: [artifactsPublisher(disabled: true), junitPublisher(disabled: true)]) {
-                    sh "mvn -DskipTests deploy " +
-                            "-DaltReleaseDeploymentRepository=utarwyn::default::https://repo.utarwyn.fr/releases/ " +
-                            "-DaltSnapshotDeploymentRepository=utarwyn::default::https://repo.utarwyn.fr/snapshots/"
+            if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME == 'next') {
+                steps {
+                    withMaven(options: [artifactsPublisher(disabled: true), junitPublisher(disabled: true)]) {
+                        sh "mvn -DskipTests deploy " +
+                                "-DaltReleaseDeploymentRepository=utarwyn::default::https://repo.utarwyn.fr/releases/ " +
+                                "-DaltSnapshotDeploymentRepository=utarwyn::default::https://repo.utarwyn.fr/snapshots/"
+                    }
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,13 +19,14 @@ pipeline {
         }
 
         stage('Deploy') {
-            if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME == 'next') {
-                steps {
-                    withMaven(options: [artifactsPublisher(disabled: true), junitPublisher(disabled: true)]) {
-                        sh "mvn -DskipTests deploy " +
-                                "-DaltReleaseDeploymentRepository=utarwyn::default::https://repo.utarwyn.fr/releases/ " +
-                                "-DaltSnapshotDeploymentRepository=utarwyn::default::https://repo.utarwyn.fr/snapshots/"
-                    }
+            when {
+                expression { env.BRANCH_NAME == 'master' || env.BRANCH_NAME == 'next' }
+            }
+            steps {
+                withMaven(options: [artifactsPublisher(disabled: true), junitPublisher(disabled: true)]) {
+                    sh "mvn -DskipTests deploy " +
+                            "-DaltReleaseDeploymentRepository=utarwyn::default::https://repo.utarwyn.fr/releases/ " +
+                            "-DaltSnapshotDeploymentRepository=utarwyn::default::https://repo.utarwyn.fr/snapshots/"
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <h4 align="center">
 A modern Bukkit plugin to divide enderchest into multiple inventories.
 <br>
-Works with Bukkit/Spigot 1.8 to 1.17!
+Works with Bukkit/Spigot 1.8 to 1.18!
 </h4>
 
 <p align="center">

--- a/plugin/src/main/java/fr/utarwyn/endercontainers/compatibility/ServerVersion.java
+++ b/plugin/src/main/java/fr/utarwyn/endercontainers/compatibility/ServerVersion.java
@@ -19,7 +19,8 @@ public enum ServerVersion {
     V1_14,
     V1_15,
     V1_16,
-    V1_17;
+    V1_17,
+    V1_18;
 
     private static ServerVersion currentVersion;
 

--- a/plugin/src/main/java/fr/utarwyn/endercontainers/compatibility/nms/NMSPlayerUtil.java
+++ b/plugin/src/main/java/fr/utarwyn/endercontainers/compatibility/nms/NMSPlayerUtil.java
@@ -17,8 +17,6 @@ import java.util.UUID;
  */
 public class NMSPlayerUtil extends NMSUtil {
 
-    private static final String GET_WORLD_SERVER_METHOD = "getWorldServer";
-
     /**
      * Singleton instance of the utility class.
      */
@@ -34,6 +32,8 @@ public class NMSPlayerUtil extends NMSUtil {
 
     private final Object worldServer;
 
+    private final String methodGetWorldServer;
+
     private Object playerInteractManager;
 
     /**
@@ -46,6 +46,9 @@ public class NMSPlayerUtil extends NMSUtil {
         Class<?> minecraftServerClass = getNMSClass("MinecraftServer", "server");
         Class<?> gameProfileClass = Class.forName("com.mojang.authlib.GameProfile");
         Class<?> worldServerClass = getNMSClass("WorldServer", "server.level");
+
+        // 1.18+ :: New method names
+        methodGetWorldServer = ServerVersion.isNewerThan(ServerVersion.V1_17) ? "a" : "getWorldServer";
 
         gameProfileContructor = gameProfileClass.getDeclaredConstructor(UUID.class, String.class);
         minecraftServer = minecraftServerClass.getMethod("getServer").invoke(null);
@@ -127,7 +130,7 @@ public class NMSPlayerUtil extends NMSUtil {
         Object resourceKey = constructResourceKey.invoke(null, dimensionKey, overworldKey);
         constructResourceKey.setAccessible(false);
 
-        Method getWorldServer = minecraftServerClass.getDeclaredMethod(GET_WORLD_SERVER_METHOD, genericResourceKey);
+        Method getWorldServer = minecraftServerClass.getDeclaredMethod(methodGetWorldServer, genericResourceKey);
         return getWorldServer.invoke(minecraftServer, resourceKey);
     }
 
@@ -139,11 +142,11 @@ public class NMSPlayerUtil extends NMSUtil {
             } else {
                 Class<?> dimensionManagerClass = getNMSClass("DimensionManager", null);
                 Object dimension = dimensionManagerClass.getDeclaredField("OVERWORLD").get(null);
-                Method method = minecraftServerClass.getMethod(GET_WORLD_SERVER_METHOD, dimensionManagerClass);
+                Method method = minecraftServerClass.getMethod(methodGetWorldServer, dimensionManagerClass);
                 server = method.invoke(minecraftServer, dimension);
             }
         } else {
-            Method method = minecraftServerClass.getMethod(GET_WORLD_SERVER_METHOD, int.class);
+            Method method = minecraftServerClass.getMethod(methodGetWorldServer, int.class);
             server = method.invoke(minecraftServer, 0);
         }
 

--- a/plugin/src/main/java/fr/utarwyn/endercontainers/compatibility/nms/NMSUtil.java
+++ b/plugin/src/main/java/fr/utarwyn/endercontainers/compatibility/nms/NMSUtil.java
@@ -87,14 +87,14 @@ public abstract class NMSUtil {
      *
      * @param clazz          class where the method is located
      * @param name           name used before Minecraft 1.18
-     * @param name1_18       name introduced with Minecraft 1.18
+     * @param name18         name introduced with Minecraft 1.18
      * @param parameterTypes parameter types
      * @return located method
      * @throws NoSuchMethodException thrown if method has not been found
      */
-    protected static Method getNMSDynamicMethod(Class<?> clazz, String name, String name1_18, Class<?>... parameterTypes)
+    protected static Method getNMSDynamicMethod(Class<?> clazz, String name, String name18, Class<?>... parameterTypes)
             throws NoSuchMethodException {
-        return clazz.getMethod(ServerVersion.isNewerThan(ServerVersion.V1_17) ? name1_18 : name, parameterTypes);
+        return clazz.getMethod(ServerVersion.isNewerThan(ServerVersion.V1_17) ? name18 : name, parameterTypes);
     }
 
     /**

--- a/plugin/src/main/java/fr/utarwyn/endercontainers/compatibility/nms/NMSUtil.java
+++ b/plugin/src/main/java/fr/utarwyn/endercontainers/compatibility/nms/NMSUtil.java
@@ -3,6 +3,7 @@ package fr.utarwyn.endercontainers.compatibility.nms;
 import fr.utarwyn.endercontainers.compatibility.ServerVersion;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 
 /**
  * Base class to perform reflection things on current server net classes.
@@ -78,6 +79,22 @@ public abstract class NMSUtil {
     protected static Class<?> getNMSClass(String className, String package1_17)
             throws ClassNotFoundException {
         return Class.forName((MC_PACKAGE != null ? MC_PACKAGE + package1_17 + "." : NMS_PACKAGE) + className);
+    }
+
+    /**
+     * Get an internal net Minecraft Server method with a name changes.
+     * Usefull from Minecraft 1.18 because of minifier.
+     *
+     * @param clazz          class where the method is located
+     * @param name           name used before Minecraft 1.18
+     * @param name1_18       name introduced with Minecraft 1.18
+     * @param parameterTypes parameter types
+     * @return located method
+     * @throws NoSuchMethodException thrown if method has not been found
+     */
+    protected static Method getNMSDynamicMethod(Class<?> clazz, String name, String name1_18, Class<?>... parameterTypes)
+            throws NoSuchMethodException {
+        return clazz.getMethod(ServerVersion.isNewerThan(ServerVersion.V1_17) ? name1_18 : name, parameterTypes);
     }
 
     /**

--- a/plugin/src/test/java/fr/utarwyn/endercontainers/TestHelper.java
+++ b/plugin/src/test/java/fr/utarwyn/endercontainers/TestHelper.java
@@ -1,5 +1,6 @@
 package fr.utarwyn.endercontainers;
 
+import fr.utarwyn.endercontainers.compatibility.ServerVersion;
 import fr.utarwyn.endercontainers.compatibility.nms.NMSHologramUtil;
 import fr.utarwyn.endercontainers.configuration.Configuration;
 import fr.utarwyn.endercontainers.configuration.Files;
@@ -235,6 +236,22 @@ public class TestHelper {
         field.setAccessible(false);
 
         filesReady = false;
+    }
+
+    /**
+     * Overrides server version.
+     *
+     * @param version version to force
+     */
+    public static void overrideServerVersion(ServerVersion version) {
+        try {
+            Field currentVersion = ServerVersion.class.getDeclaredField("currentVersion");
+            currentVersion.setAccessible(true);
+            currentVersion.set(null, version);
+            currentVersion.setAccessible(false);
+        } catch (ReflectiveOperationException e) {
+            e.printStackTrace();
+        }
     }
 
     /**

--- a/plugin/src/test/java/fr/utarwyn/endercontainers/compatibility/nms/NMSUtilTest.java
+++ b/plugin/src/test/java/fr/utarwyn/endercontainers/compatibility/nms/NMSUtilTest.java
@@ -28,10 +28,12 @@ public class NMSUtilTest {
 
     @Test
     public void getNMSDynamicMethod() throws ReflectiveOperationException {
+        ServerVersion defVersion = ServerVersion.get();
         overrideServerVersion(ServerVersion.V1_8);
         assertThat(NMSUtil.getNMSDynamicMethod(String.class, "toLowerCase", "toUpperCase").invoke("TeSt")).isEqualTo("test");
         overrideServerVersion(ServerVersion.V1_18);
         assertThat(NMSUtil.getNMSDynamicMethod(String.class, "toLowerCase", "toUpperCase").invoke("TeSt")).isEqualTo("TEST");
+        overrideServerVersion(defVersion);
     }
 
 }

--- a/plugin/src/test/java/fr/utarwyn/endercontainers/compatibility/nms/NMSUtilTest.java
+++ b/plugin/src/test/java/fr/utarwyn/endercontainers/compatibility/nms/NMSUtilTest.java
@@ -1,0 +1,37 @@
+package fr.utarwyn.endercontainers.compatibility.nms;
+
+import fr.utarwyn.endercontainers.TestHelper;
+import fr.utarwyn.endercontainers.compatibility.ServerVersion;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static fr.utarwyn.endercontainers.TestHelper.overrideServerVersion;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+public class NMSUtilTest {
+
+    @BeforeClass
+    public static void setUpClass() {
+        TestHelper.setUpServer();
+    }
+
+    @Test
+    public void getNMSClass() {
+        try {
+            NMSUtil.getNMSClass("Fake", "package1_17");
+            fail("class retrieving must fail");
+        } catch (ClassNotFoundException e) {
+            assertThat(e.getMessage()).isEqualTo("net.minecraft.server.v1_15.Fake");
+        }
+    }
+
+    @Test
+    public void getNMSDynamicMethod() throws ReflectiveOperationException {
+        overrideServerVersion(ServerVersion.V1_8);
+        assertThat(NMSUtil.getNMSDynamicMethod(String.class, "toLowerCase", "toUpperCase").invoke("TeSt")).isEqualTo("test");
+        overrideServerVersion(ServerVersion.V1_18);
+        assertThat(NMSUtil.getNMSDynamicMethod(String.class, "toLowerCase", "toUpperCase").invoke("TeSt")).isEqualTo("TEST");
+    }
+
+}

--- a/plugin/src/test/java/fr/utarwyn/endercontainers/storage/serialization/Base64ItemSerializerTest.java
+++ b/plugin/src/test/java/fr/utarwyn/endercontainers/storage/serialization/Base64ItemSerializerTest.java
@@ -38,22 +38,22 @@ public class Base64ItemSerializerTest {
                 .isBase64()
                 .isEqualTo("rO0ABXcIAAAAAgAAAAFzcgAab3JnLmJ1a2tpdC51dGlsLmlvLldyYXBwZXLyUEfs8RJv" +
                         "BQIAAUwAA21hcHQAD0xqYXZhL3V0aWwvTWFwO3hwc3IANWNvbS5nb29nbGUuY29tbW9uLmN" +
-                        "vbGxlY3QuSW1tdXRhYmxlTWFwJFNlcmlhbGl6ZWRGb3JtAAAAAAAAAAACAAJbAARrZXlzdA" +
-                        "ATW0xqYXZhL2xhbmcvT2JqZWN0O1sABnZhbHVlc3EAfgAEeHB1cgATW0xqYXZhLmxhbmcuT" +
-                        "2JqZWN0O5DOWJ8QcylsAgAAeHAAAAAFdAACPT10AAF2dAAEdHlwZXQABmFtb3VudHQABG1l" +
-                        "dGF1cQB+AAYAAAAFdAAeb3JnLmJ1a2tpdC5pbnZlbnRvcnkuSXRlbVN0YWNrc3IAEWphdmE" +
-                        "ubGFuZy5JbnRlZ2VyEuKgpPeBhzgCAAFJAAV2YWx1ZXhyABBqYXZhLmxhbmcuTnVtYmVyhq" +
-                        "yVHQuU4IsCAAB4cAAAAAF0AAdPQUtfTE9Hc3EAfgAPAAAACnNxAH4AAHNxAH4AA3VxAH4AB" +
-                        "gAAAAVxAH4ACHQACGVuY2hhbnRzdAAGZGFtYWdldAAEbG9yZXQAC2Rpc3BsYXlOYW1ldXEA" +
-                        "fgAGAAAABXQALGZyLnV0YXJ3eW4uZW5kZXJjb250YWluZXJzLm1vY2suSXRlbU1ldGFNb2N" +
-                        "rc3IAJWphdmEudXRpbC5Db2xsZWN0aW9ucyRVbm1vZGlmaWFibGVNYXDxpaj+dPUHQgIAAU" +
-                        "wAAW1xAH4AAXhwc3IAEWphdmEudXRpbC5IYXNoTWFwBQfawcMWYNEDAAJGAApsb2FkRmFjd" +
-                        "G9ySQAJdGhyZXNob2xkeHA/QAAAAAAAAHcIAAAAEAAAAAB4c3EAfgAPAAAAAHNyABNqYXZh" +
-                        "LnV0aWwuQXJyYXlMaXN0eIHSHZnHYZ0DAAFJAARzaXpleHAAAAAAdwQAAAAAeHQAAHcEAAA" +
-                        "AEXNxAH4AAHNxAH4AA3VxAH4ABgAAAAVxAH4ACHEAfgAJcQB+AApxAH4AC3EAfgAMdXEAfg" +
-                        "AGAAAABXEAfgAOcQB+ABF0AAVHUkFTU3NxAH4ADwAAABRzcQB+AABzcQB+AAN1cQB+AAYAA" +
-                        "AAFcQB+AAhxAH4AF3EAfgAYcQB+ABlxAH4AGnVxAH4ABgAAAAVxAH4AHHNxAH4AHXNxAH4A" +
-                        "Hz9AAAAAAAAAdwgAAAAQAAAAAHhxAH4AIXNxAH4AIgAAAAB3BAAAAAB4cQB+ACQ=");
+                        "vbGxlY3QuSW1tdXRhYmxlTWFwJFNlcmlhbGl6ZWRGb3JtAAAAAAAAAAACAAJMAARrZXlzdA" +
+                        "ASTGphdmEvbGFuZy9PYmplY3Q7TAAGdmFsdWVzcQB+AAR4cHVyABNbTGphdmEubGFuZy5PY" +
+                        "mplY3Q7kM5YnxBzKWwCAAB4cAAAAAV0AAI9PXQAAXZ0AAR0eXBldAAGYW1vdW50dAAEbWV0" +
+                        "YXVxAH4ABgAAAAV0AB5vcmcuYnVra2l0LmludmVudG9yeS5JdGVtU3RhY2tzcgARamF2YS5" +
+                        "sYW5nLkludGVnZXIS4qCk94GHOAIAAUkABXZhbHVleHIAEGphdmEubGFuZy5OdW1iZXKGrJ" +
+                        "UdC5TgiwIAAHhwAAAAAXQAB09BS19MT0dzcQB+AA8AAAAKc3EAfgAAc3EAfgADdXEAfgAGA" +
+                        "AAABXEAfgAIdAAIZW5jaGFudHN0AAZkYW1hZ2V0AARsb3JldAALZGlzcGxheU5hbWV1cQB+" +
+                        "AAYAAAAFdAAsZnIudXRhcnd5bi5lbmRlcmNvbnRhaW5lcnMubW9jay5JdGVtTWV0YU1vY2t" +
+                        "zcgAlamF2YS51dGlsLkNvbGxlY3Rpb25zJFVubW9kaWZpYWJsZU1hcPGlqP509QdCAgABTA" +
+                        "ABbXEAfgABeHBzcgARamF2YS51dGlsLkhhc2hNYXAFB9rBwxZg0QMAAkYACmxvYWRGYWN0b" +
+                        "3JJAAl0aHJlc2hvbGR4cD9AAAAAAAAAdwgAAAAQAAAAAHhzcQB+AA8AAAAAc3IAE2phdmEu" +
+                        "dXRpbC5BcnJheUxpc3R4gdIdmcdhnQMAAUkABHNpemV4cAAAAAB3BAAAAAB4dAAAdwQAAAA" +
+                        "Rc3EAfgAAc3EAfgADdXEAfgAGAAAABXEAfgAIcQB+AAlxAH4ACnEAfgALcQB+AAx1cQB+AA" +
+                        "YAAAAFcQB+AA5xAH4AEXQABUdSQVNTc3EAfgAPAAAAFHNxAH4AAHNxAH4AA3VxAH4ABgAAA" +
+                        "AVxAH4ACHEAfgAXcQB+ABhxAH4AGXEAfgAadXEAfgAGAAAABXEAfgAcc3EAfgAdc3EAfgAf" +
+                        "P0AAAAAAAAB3CAAAABAAAAAAeHEAfgAhc3EAfgAiAAAAAHcEAAAAAHhxAH4AJA==");
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <bukkit-api.version>1.17.1-R0.1-SNAPSHOT</bukkit-api.version>
+        <bukkit-api.version>1.18-R0.1-SNAPSHOT</bukkit-api.version>
         <junit.version>4.13.1</junit.version>
         <mockito.version>3.8.0</mockito.version>
         <assertj.version>3.19.0</assertj.version>


### PR DESCRIPTION
## Description
<!-- Please explain your changes in detail. -->
**We are getting used to it, it's time to update the plugin to support the new version of Minecraft!**

**Changes I made are backwards compatible**, so the plugin still works on version 1.8. 🎉
I have done some tests on Minecraft 1.8, Minecraft 1.17 and Minecraft 1.18 and it seems to work well.

> **Want to preview this addition?**
> Check latest artifacts [by clicking here](https://ci.utarwyn.fr/job/EnderContainers/view/change-requests/job/PR-184/). *(will be removed after closing PR)*

## Changes
<!-- Please list all the changes you have made. -->
- Add **V1_18** in `ServerVersion`
- Update utility classes to support NMS 1.18 (Hologram, Player)
- Upgrade spigot-api to `1.18-R0.1-SNAPSHOT`
- Update README

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
Resolves #183

## Checklist
<!-- After posting your issue, please check the boxes below if they apply -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.