### PR TITLE
Support Minecraft 1.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <h4 align="center">
 A modern Bukkit plugin to divide enderchest into multiple inventories.
 <br>
-Works with Bukkit/Spigot 1.8 to 1.18!
+Works with Bukkit/Spigot 1.8 to 1.19!
 </h4>
 
 <p align="center">

--- a/dependencies/PlotSquared/pom.xml
+++ b/dependencies/PlotSquared/pom.xml
@@ -15,9 +15,9 @@
     <name>EnderContainers Dependency PlotSquared</name>
 
     <properties>
-        <plotsquared.version>5.13.3</plotsquared.version>
+        <plotsquared.version>5.13.11</plotsquared.version>
         <worldedit.version>7.2.3</worldedit.version>
-        <prtree.version>1.7.0-SNAPSHOT</prtree.version>
+        <prtree.version>1.7.0</prtree.version>
     </properties>
 
     <repositories>
@@ -26,12 +26,8 @@
             <url>https://maven.enginehub.org/repo/</url>
         </repository>
         <repository>
-            <id>plotsquared-releases</id>
-            <url>https://mvn.intellectualsites.com/content/repositories/releases/</url>
-        </repository>
-        <repository>
-            <id>plotsquared-snapshots</id>
-            <url>https://mvn.intellectualsites.com/content/repositories/snapshots/</url>
+            <id>utarwyn</id>
+            <url>https://repo.utarwyn.fr</url>
         </repository>
     </repositories>
 

--- a/plugin/src/main/java/fr/utarwyn/endercontainers/compatibility/CompatibilityHelper.java
+++ b/plugin/src/main/java/fr/utarwyn/endercontainers/compatibility/CompatibilityHelper.java
@@ -1,7 +1,6 @@
 package fr.utarwyn.endercontainers.compatibility;
 
 import com.google.common.base.Preconditions;
-import org.apache.commons.lang.StringUtils;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.enchantments.Enchantment;
@@ -125,17 +124,19 @@ public class CompatibilityHelper {
     }
 
     public static Enchantment enchantmentFromString(String value) {
-        if (!StringUtils.isNumeric(value)) { // Name or NamespacedKey
+        try {
+            // Legacy method: use the name (old versions of Bukkit)
+            int numericValue = Integer.parseInt(value);
+            return Enchantment.getByName(ENCHANT_BY_IDS.get(numericValue));
+        } catch (NumberFormatException e) {
+            // Name or NamespacedKey
             if (ServerVersion.isNewerThan(V1_12) && value.contains("!")) {
                 // New method to get en enchantment!
                 String[] parts = value.split("!");
                 return Enchantment.getByKey(new NamespacedKey(parts[0], parts[1]));
             } else {
-                // Legacy method: use the name (old versions of Bukkit)
                 return Enchantment.getByName(value);
             }
-        } else { // Legacy support for enchant ids
-            return Enchantment.getByName(ENCHANT_BY_IDS.get(Integer.valueOf(value)));
         }
     }
 

--- a/plugin/src/main/java/fr/utarwyn/endercontainers/compatibility/ServerVersion.java
+++ b/plugin/src/main/java/fr/utarwyn/endercontainers/compatibility/ServerVersion.java
@@ -20,7 +20,8 @@ public enum ServerVersion {
     V1_15,
     V1_16,
     V1_17,
-    V1_18;
+    V1_18,
+    V1_19;
 
     private static ServerVersion currentVersion;
 

--- a/plugin/src/main/java/fr/utarwyn/endercontainers/compatibility/nms/NMSHologramUtil.java
+++ b/plugin/src/main/java/fr/utarwyn/endercontainers/compatibility/nms/NMSHologramUtil.java
@@ -92,7 +92,11 @@ public class NMSHologramUtil extends NMSUtil {
         Class<?> armorStandClass = getNMSClass("EntityArmorStand", "world.entity.decoration");
         Class<?> entityPlayerClass = getNMSClass("EntityPlayer", "server.level");
         Class<?> destroyPacketClass = getNMSClass("PacketPlayOutEntityDestroy", "network.protocol.game");
-        Class<?> spawnPacketClass = getNMSClass("PacketPlayOutSpawnEntityLiving", "network.protocol.game");
+
+        // 1.19+ :: PacketPlayOutSpawnEntityLiving has been renamed PacketPlayOutSpawnEntity
+        String spawnPacketClassName = ServerVersion.isNewerThan(ServerVersion.V1_18)
+                ? "PacketPlayOutSpawnEntity" : "PacketPlayOutSpawnEntityLiving";
+        Class<?> spawnPacketClass = getNMSClass(spawnPacketClassName, "network.protocol.game");
 
         this.packetClass = getNMSClass("Packet", "network.protocol");
         this.entityClass = getNMSClass("Entity", "world.entity");
@@ -257,8 +261,10 @@ public class NMSHologramUtil extends NMSUtil {
             Method fromStringOrNullMethod = this.chatMessageClass.getMethod("fromStringOrNull", String.class);
             Object chatComponent = fromStringOrNullMethod.invoke(null, text);
 
-            Method setCustomName = getNMSDynamicMethod(entityObject.getClass(), "setCustomName", "a", this.chatBaseComponentClass);
-            setCustomName.invoke(entityObject, chatComponent);
+            // 1.19+ :: method is now "b" (instead of "a")
+            String methodNamePost17 = ServerVersion.isNewerThan(ServerVersion.V1_18) ? "b" : "a";
+            getNMSDynamicMethod(entityObject.getClass(), "setCustomName", methodNamePost17, this.chatBaseComponentClass)
+                    .invoke(entityObject, chatComponent);
         } else {
             Method setCustomName = entityObject.getClass().getMethod("setCustomName", String.class);
             setCustomName.invoke(entityObject, text);

--- a/plugin/src/main/java/fr/utarwyn/endercontainers/compatibility/nms/NMSPlayerUtil.java
+++ b/plugin/src/main/java/fr/utarwyn/endercontainers/compatibility/nms/NMSPlayerUtil.java
@@ -55,8 +55,14 @@ public class NMSPlayerUtil extends NMSUtil {
         getBukkitEntityMethod = entityPlayerClass.getDeclaredMethod("getBukkitEntity");
         worldServer = this.prepareWorldServer(minecraftServerClass);
 
-        // 1.17+ :: we do not have to pass PlayerInteractManager to entity player constructor
-        if (ServerVersion.isNewerThan(ServerVersion.V1_16)) {
+        if (ServerVersion.isNewerThan(ServerVersion.V1_18)) {
+            // 1.19+ :: constructor also need a public key
+            Class<?> publicKeyClass = getNMSClass("ProfilePublicKey", "world.entity.player");
+            entityPlayerConstructor = entityPlayerClass.getDeclaredConstructor(
+                    minecraftServerClass, worldServerClass, gameProfileClass, publicKeyClass
+            );
+        } else if (ServerVersion.isNewerThan(ServerVersion.V1_16)) {
+            // 1.17+ :: we do not have to pass PlayerInteractManager to entity player constructor
             entityPlayerConstructor = entityPlayerClass.getDeclaredConstructor(
                     minecraftServerClass, worldServerClass, gameProfileClass
             );
@@ -102,7 +108,12 @@ public class NMSPlayerUtil extends NMSUtil {
 
         // 1.17+ :: we do not have to pass PlayerInteractManager to entity player constructor
         if (playerInteractManager == null) {
-            entityPlayer = entityPlayerConstructor.newInstance(minecraftServer, worldServer, gameProfile);
+            // 1.19+ :: constructor also need a public key
+            if (ServerVersion.isNewerThan(ServerVersion.V1_18)) {
+                entityPlayer = entityPlayerConstructor.newInstance(minecraftServer, worldServer, gameProfile, null);
+            } else {
+                entityPlayer = entityPlayerConstructor.newInstance(minecraftServer, worldServer, gameProfile);
+            }
         } else {
             entityPlayer = entityPlayerConstructor.newInstance(minecraftServer, worldServer, gameProfile, playerInteractManager);
         }

--- a/plugin/src/main/java/fr/utarwyn/endercontainers/compatibility/nms/NMSUtil.java
+++ b/plugin/src/main/java/fr/utarwyn/endercontainers/compatibility/nms/NMSUtil.java
@@ -83,18 +83,19 @@ public abstract class NMSUtil {
 
     /**
      * Get an internal net Minecraft Server method with a name changes.
-     * Usefull from Minecraft 1.18 because of minifier.
+     * Useful since Minecraft 1.18 because of minifiers.
      *
      * @param clazz          class where the method is located
      * @param name           name used before Minecraft 1.18
-     * @param name18         name introduced with Minecraft 1.18
+     * @param namePost17     name introduced after Minecraft 1.17
      * @param parameterTypes parameter types
      * @return located method
      * @throws NoSuchMethodException thrown if method has not been found
      */
-    protected static Method getNMSDynamicMethod(Class<?> clazz, String name, String name18, Class<?>... parameterTypes)
-            throws NoSuchMethodException {
-        return clazz.getMethod(ServerVersion.isNewerThan(ServerVersion.V1_17) ? name18 : name, parameterTypes);
+    protected static Method getNMSDynamicMethod(
+            Class<?> clazz, String name, String namePost17, Class<?>... parameterTypes
+    ) throws NoSuchMethodException {
+        return clazz.getMethod(ServerVersion.isNewerThan(ServerVersion.V1_17) ? namePost17 : name, parameterTypes);
     }
 
     /**

--- a/plugin/src/main/java/fr/utarwyn/endercontainers/database/request/DeleteRequest.java
+++ b/plugin/src/main/java/fr/utarwyn/endercontainers/database/request/DeleteRequest.java
@@ -1,7 +1,7 @@
 package fr.utarwyn.endercontainers.database.request;
 
+import com.google.common.base.Joiner;
 import fr.utarwyn.endercontainers.database.Database;
-import org.apache.commons.lang.StringUtils;
 
 import java.sql.SQLException;
 
@@ -83,7 +83,7 @@ public class DeleteRequest implements Request {
         // Construct conditions if exists
         if (this.conditions.length > 0) {
             sb.append(" WHERE ");
-            sb.append(StringUtils.join(this.conditions, " AND "));
+            sb.append(Joiner.on(" AND ").join(this.conditions));
         }
 
         return sb.toString();

--- a/plugin/src/main/java/fr/utarwyn/endercontainers/database/request/SavingRequest.java
+++ b/plugin/src/main/java/fr/utarwyn/endercontainers/database/request/SavingRequest.java
@@ -1,8 +1,8 @@
 package fr.utarwyn.endercontainers.database.request;
 
+import com.google.common.base.Joiner;
 import fr.utarwyn.endercontainers.database.Database;
 import fr.utarwyn.endercontainers.database.DatabaseManager;
-import org.apache.commons.lang.StringUtils;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -130,12 +130,12 @@ public class SavingRequest implements Request {
             }
             request.deleteCharAt(request.length() - 1);
 
-            request.append(" WHERE ").append(StringUtils.join(this.conditions, " AND "));
+            request.append(" WHERE ").append(Joiner.on(" AND ").join(this.conditions));
         } else {
             String action = this.replaceIfExists ? "REPLACE" : "INSERT";
 
             request.append(action).append(" INTO `").append(this.table).append('`');
-            request.append("(").append(StringUtils.join(this.fields, ",")).append(")");
+            request.append("(").append(Joiner.on(',').join(this.fields)).append(")");
 
             request.append(" VALUES ");
             request.append("(").append(this.generateFakeParameters(this.values)).append(")");
@@ -145,7 +145,7 @@ public class SavingRequest implements Request {
     }
 
     private String generateFakeParameters(Object[] values) {
-        return StringUtils.join(Arrays.stream(values).map(v -> '?').toArray(), ",");
+        return Joiner.on(',').join(Arrays.stream(values).map(v -> '?').toArray());
     }
 
 }

--- a/plugin/src/main/java/fr/utarwyn/endercontainers/database/request/SelectRequest.java
+++ b/plugin/src/main/java/fr/utarwyn/endercontainers/database/request/SelectRequest.java
@@ -1,9 +1,9 @@
 package fr.utarwyn.endercontainers.database.request;
 
+import com.google.common.base.Joiner;
 import fr.utarwyn.endercontainers.database.Database;
 import fr.utarwyn.endercontainers.database.DatabaseManager;
 import fr.utarwyn.endercontainers.database.DatabaseSet;
-import org.apache.commons.lang.StringUtils;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -119,9 +119,9 @@ public class SelectRequest implements Request {
     public String getRequest() {
         StringBuilder request = new StringBuilder("SELECT ");
 
-        request.append(StringUtils.join(this.fields, ","));
+        request.append(Joiner.on(',').join(this.fields));
         request.append(" FROM ");
-        request.append(StringUtils.join(this.froms, ","));
+        request.append(Joiner.on(',').join(this.froms));
 
         for (String[] join : this.joins) {
             request.append(" JOIN ").append(join[0]).append(" ON ").append(join[1]).append(" = ").append(join[2]);
@@ -132,13 +132,13 @@ public class SelectRequest implements Request {
         }
 
         if (this.conditions.length > 0) {
-            request.append(" WHERE ").append(StringUtils.join(this.conditions, " AND "));
+            request.append(" WHERE ").append(Joiner.on(" AND ").join(this.conditions));
         }
         if (this.groupsBy.length > 0) {
-            request.append(" GROUP BY ").append(StringUtils.join(this.groupsBy, ","));
+            request.append(" GROUP BY ").append(Joiner.on(',').join(this.groupsBy));
         }
         if (this.orders.length > 0) {
-            request.append(" ORDER BY ").append(StringUtils.join(this.orders, ","));
+            request.append(" ORDER BY ").append(Joiner.on(',').join(this.orders));
         }
         if (this.limits.length > 0) {
             if (this.limits[1] > 0) { // limites

--- a/plugin/src/main/java/fr/utarwyn/endercontainers/storage/serialization/LegacyItemSerializer.java
+++ b/plugin/src/main/java/fr/utarwyn/endercontainers/storage/serialization/LegacyItemSerializer.java
@@ -1,7 +1,6 @@
 package fr.utarwyn.endercontainers.storage.serialization;
 
 import fr.utarwyn.endercontainers.compatibility.CompatibilityHelper;
-import org.apache.commons.lang.StringUtils;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemStack;
@@ -140,9 +139,9 @@ public class LegacyItemSerializer implements ItemSerializer {
                     Material material;
 
                     // Material ids is an old way to store items, now we use material names (more reliable).
-                    if (StringUtils.isNumeric(value)) {
+                    try {
                         material = CompatibilityHelper.materialFromId(Integer.parseInt(value));
-                    } else {
+                    } catch (NumberFormatException e) {
                         material = CompatibilityHelper.matchMaterial(value);
                     }
 

--- a/plugin/src/main/java/fr/utarwyn/endercontainers/util/PluginMsg.java
+++ b/plugin/src/main/java/fr/utarwyn/endercontainers/util/PluginMsg.java
@@ -1,9 +1,9 @@
 package fr.utarwyn.endercontainers.util;
 
+import com.google.common.base.Strings;
 import fr.utarwyn.endercontainers.EnderContainers;
 import fr.utarwyn.endercontainers.configuration.Files;
 import fr.utarwyn.endercontainers.configuration.LocaleKey;
-import org.apache.commons.lang.StringUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -132,8 +132,8 @@ public class PluginMsg {
      * @param receiver receiver of the message
      */
     public static void pluginBar(CommandSender receiver) {
-        String pBar = "§5§m" + StringUtils.repeat("-", 5);
-        String sBar = "§d§m" + StringUtils.repeat("-", 11);
+        String pBar = "§5§m" + Strings.repeat("-", 5);
+        String sBar = "§d§m" + Strings.repeat("-", 11);
 
         receiver.sendMessage("§8++" + pBar + sBar + "§r§d( §6EnderContainers §d)" + sBar + pBar + "§8++");
     }
@@ -144,8 +144,8 @@ public class PluginMsg {
      * @param receiver receiver of the message
      */
     public static void endBar(CommandSender receiver) {
-        String pBar = "§5§m" + StringUtils.repeat("-", 5);
-        receiver.sendMessage("§8++" + pBar + "§d§m" + StringUtils.repeat("-", 39) + pBar + "§8++");
+        String pBar = "§5§m" + Strings.repeat("-", 5);
+        receiver.sendMessage("§8++" + pBar + "§d§m" + Strings.repeat("-", 39) + pBar + "§8++");
     }
 
     /**

--- a/plugin/src/main/java/fr/utarwyn/endercontainers/util/SemanticVersion.java
+++ b/plugin/src/main/java/fr/utarwyn/endercontainers/util/SemanticVersion.java
@@ -1,7 +1,7 @@
 package fr.utarwyn.endercontainers.util;
 
 import com.google.common.base.Objects;
-import org.apache.commons.lang.Validate;
+import com.google.common.base.Preconditions;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -46,7 +46,7 @@ public class SemanticVersion implements Comparable<SemanticVersion> {
      * @param version semantic version in a string format
      */
     public SemanticVersion(String version) {
-        Validate.notNull(version, "semantic version cannot be null");
+        Preconditions.checkArgument(version != null, "semantic version cannot be null");
         Matcher matcher = Pattern.compile(REGEX).matcher(version);
 
         if (!matcher.matches()) {

--- a/plugin/src/test/java/fr/utarwyn/endercontainers/enderchest/EnderChestListenerTest.java
+++ b/plugin/src/test/java/fr/utarwyn/endercontainers/enderchest/EnderChestListenerTest.java
@@ -169,20 +169,22 @@ public class EnderChestListenerTest {
         Updater updater = mock(Updater.class);
         TestHelper.registerManagers(updater);
 
+        when(this.player.getLocation()).thenReturn(mock(Location.class));
+
         // no permission
         this.listener.onPlayerJoin(event);
-        verify(this.player, never()).playSound(any(), any(Sound.class), eq(1f), eq(1f));
+        verify(this.player, never()).playSound(any(Location.class), any(Sound.class), eq(1f), eq(1f));
 
         // no update
         when(this.player.isOp()).thenReturn(true);
         when(updater.notifyPlayer(this.player)).thenReturn(false);
         this.listener.onPlayerJoin(event);
-        verify(this.player, never()).playSound(any(), any(Sound.class), eq(1f), eq(1f));
+        verify(this.player, never()).playSound(any(Location.class), any(Sound.class), eq(1f), eq(1f));
 
         // update and permission
         when(updater.notifyPlayer(this.player)).thenReturn(true);
         this.listener.onPlayerJoin(event);
-        verify(this.player).playSound(any(), eq(Sound.BLOCK_NOTE_BLOCK_PLING), eq(1f), eq(1f));
+        verify(this.player).playSound(any(Location.class), eq(Sound.BLOCK_NOTE_BLOCK_PLING), eq(1f), eq(1f));
     }
 
     @Test
@@ -241,19 +243,19 @@ public class EnderChestListenerTest {
         // try with an unknown entity -> no sound
         when(event.getPlayer()).thenReturn(mock(HumanEntity.class));
         this.listener.onInventoryClose(event);
-        verify(this.player, never()).playSound(any(), any(Sound.class), anyFloat(), anyFloat());
+        verify(this.player, never()).playSound(any(Location.class), any(Sound.class), anyFloat(), anyFloat());
 
         // try with another type of container -> no sound
         when(event.getPlayer()).thenReturn(this.player);
         when(event.getInventory().getType()).thenReturn(InventoryType.CHEST);
         this.listener.onInventoryClose(event);
-        verify(this.player, never()).playSound(any(), any(Sound.class), anyFloat(), anyFloat());
+        verify(this.player, never()).playSound(any(Location.class), any(Sound.class), anyFloat(), anyFloat());
 
         // try with an enderchest managed by the plugin -> no sound (integrated in the inventory system)
         when(event.getInventory().getType()).thenReturn(InventoryType.ENDER_CHEST);
         when(this.manager.getVanillaEnderchestUsedBy(this.player)).thenReturn(Optional.empty());
         this.listener.onInventoryClose(event);
-        verify(this.player, never()).playSound(any(), any(Sound.class), anyFloat(), anyFloat());
+        verify(this.player, never()).playSound(any(Location.class), any(Sound.class), anyFloat(), anyFloat());
     }
 
     private PlayerInteractEvent createInteractEvent(Action action) {

--- a/plugin/src/test/java/fr/utarwyn/endercontainers/mock/ItemFactoryMock.java
+++ b/plugin/src/test/java/fr/utarwyn/endercontainers/mock/ItemFactoryMock.java
@@ -57,6 +57,11 @@ public class ItemFactoryMock implements ItemFactory {
     }
 
     @Override
+    public ItemStack createItemStack(String input) throws IllegalArgumentException {
+        return null;
+    }
+
+    @Override
     public Material updateMaterial(ItemMeta meta, Material material)
             throws IllegalArgumentException {
         return material;

--- a/plugin/src/test/java/fr/utarwyn/endercontainers/mock/ItemMetaMock.java
+++ b/plugin/src/test/java/fr/utarwyn/endercontainers/mock/ItemMetaMock.java
@@ -280,6 +280,11 @@ public class ItemMetaMock implements ItemMeta, Damageable {
     }
 
     @Override
+    public String getAsString() {
+        return "";
+    }
+
+    @Override
     public CustomItemTagContainer getCustomTagContainer() {
         throw new UnsupportedOperationException();
     }

--- a/plugin/src/test/java/fr/utarwyn/endercontainers/mock/SkullItemMetaMock.java
+++ b/plugin/src/test/java/fr/utarwyn/endercontainers/mock/SkullItemMetaMock.java
@@ -3,6 +3,7 @@ package fr.utarwyn.endercontainers.mock;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
+import org.bukkit.profile.PlayerProfile;
 
 public class SkullItemMetaMock extends ItemMetaMock implements SkullMeta {
 
@@ -37,6 +38,16 @@ public class SkullItemMetaMock extends ItemMetaMock implements SkullMeta {
     @Override
     public boolean setOwningPlayer(OfflinePlayer owner) {
         return false;
+    }
+
+    @Override
+    public PlayerProfile getOwnerProfile() {
+        return null;
+    }
+
+    @Override
+    public void setOwnerProfile(PlayerProfile profile) {
+
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <bukkit-api.version>1.18-R0.1-SNAPSHOT</bukkit-api.version>
+        <bukkit-api.version>1.19-R0.1-SNAPSHOT</bukkit-api.version>
         <junit.version>4.13.1</junit.version>
         <mockito.version>3.8.0</mockito.version>
         <assertj.version>3.19.0</assertj.version>


### PR DESCRIPTION
## Description
<!-- Please explain your changes in detail. -->
And.. another major Minecraft version is out! **It's time to update to 1.19!**

**Changes I made are backwards compatible, so the plugin still works on version 1.8.** 🎉
I have done some tests on Minecraft 1.8, Minecraft 1.18 and Minecraft 1.19 and it seems to work well.

## Changes
<!-- Please list all the changes you have made. -->
- Add **V1_19** in `ServerVersion`
- Update utility classes to support NMS 1.19 (Hologram, Player)
- Upgrade spigot-api to `1.19-R0.1-SNAPSHOT`
- Update README

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->
Resolves #202 

## Checklist
<!-- After posting your issue, please check the boxes below if they apply -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
