### PR TITLE
Fix hotbar swap restricted items

### DIFF
--- a/plugin/src/main/java/fr/utarwyn/endercontainers/inventory/InventoryManager.java
+++ b/plugin/src/main/java/fr/utarwyn/endercontainers/inventory/InventoryManager.java
@@ -5,10 +5,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.inventory.InventoryClickEvent;
-import org.bukkit.event.inventory.InventoryCloseEvent;
-import org.bukkit.event.inventory.InventoryDragEvent;
-import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.inventory.*;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
@@ -87,13 +84,21 @@ public class InventoryManager extends AbstractManager {
     public void cancelClickEventIfRestricted(
             InventoryClickEvent event, Predicate<ItemStack> itemPredicate
     ) {
-        Inventory inventory = event.getView().getTopInventory();
-        boolean validSlot = event.getRawSlot() >= 0 && event.getRawSlot() < inventory.getSize();
-        event.setCancelled((validSlot || event.isShiftClick()) && (
-                GameMode.SPECTATOR == event.getWhoClicked().getGameMode() || itemPredicate.test(
-                        event.isShiftClick() ? event.getCurrentItem() : event.getCursor()
-                )
-        ));
+        Inventory topInventory = event.getView().getTopInventory();
+        Inventory bottomInventory = event.getView().getBottomInventory();
+        boolean validSlot = event.getRawSlot() >= 0 && event.getRawSlot() < topInventory.getSize();
+        boolean isSpectator = GameMode.SPECTATOR == event.getWhoClicked().getGameMode();
+
+        ItemStack item;
+        if (event.isShiftClick()) {
+            item = event.getCurrentItem();
+        } else if (event.getAction() == InventoryAction.HOTBAR_SWAP) {
+            item = bottomInventory.getItem(event.getHotbarButton());
+        } else {
+            item = event.getCursor();
+        }
+
+        event.setCancelled((validSlot || event.isShiftClick()) && (isSpectator || itemPredicate.test(item)));
     }
 
     /**

--- a/plugin/src/main/java/fr/utarwyn/endercontainers/inventory/InventoryManager.java
+++ b/plugin/src/main/java/fr/utarwyn/endercontainers/inventory/InventoryManager.java
@@ -3,6 +3,7 @@ package fr.utarwyn.endercontainers.inventory;
 import fr.utarwyn.endercontainers.AbstractManager;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
+import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.inventory.*;
@@ -84,16 +85,19 @@ public class InventoryManager extends AbstractManager {
     public void cancelClickEventIfRestricted(
             InventoryClickEvent event, Predicate<ItemStack> itemPredicate
     ) {
+        HumanEntity whoClicked = event.getWhoClicked();
         Inventory topInventory = event.getView().getTopInventory();
         Inventory bottomInventory = event.getView().getBottomInventory();
         boolean validSlot = event.getRawSlot() >= 0 && event.getRawSlot() < topInventory.getSize();
-        boolean isSpectator = GameMode.SPECTATOR == event.getWhoClicked().getGameMode();
+        boolean isSpectator = GameMode.SPECTATOR == whoClicked.getGameMode();
 
         ItemStack item;
         if (event.isShiftClick()) {
             item = event.getCurrentItem();
         } else if (event.getAction() == InventoryAction.HOTBAR_SWAP) {
-            item = bottomInventory.getItem(event.getHotbarButton());
+            // Since `-1` is not a number slot, then we should look an item in off-hand.
+            item = event.getHotbarButton() == -1 ?
+                    whoClicked.getInventory().getItemInOffHand() : bottomInventory.getItem(event.getHotbarButton());
         } else {
             item = event.getCursor();
         }

--- a/plugin/src/main/java/fr/utarwyn/endercontainers/inventory/menu/EnderChestListMenu.java
+++ b/plugin/src/main/java/fr/utarwyn/endercontainers/inventory/menu/EnderChestListMenu.java
@@ -188,7 +188,7 @@ public class EnderChestListMenu extends AbstractInventoryHolder {
     }
 
     /**
-     * Generate an itemstack with informations of an enderchest
+     * Generate an itemstack with information of an enderchest
      * (capacity, accessibility, number, etc.)
      *
      * @param ec The enderchest processed


### PR DESCRIPTION
I noticed that players can move restricted items to endercontainers by number keys.
Hope it's fixed from now.