### PR TITLE
Save ender chest when world is saved

### DIFF
--- a/plugin/src/main/java/fr/utarwyn/endercontainers/configuration/Configuration.java
+++ b/plugin/src/main/java/fr/utarwyn/endercontainers/configuration/Configuration.java
@@ -42,7 +42,6 @@ public class Configuration {
     private final boolean blockNametag;
     private final boolean updateChecker;
     private final boolean globalSound;
-    private final boolean saveOnChestClose;
 
     /**
      * Create a configuration object from plugin configuration.
@@ -89,7 +88,6 @@ public class Configuration {
         this.blockNametag = loadValue("others.blockNametag", config::isBoolean, config::getBoolean);
         this.updateChecker = loadValue("others.updateChecker", config::isBoolean, config::getBoolean);
         this.globalSound = loadValue("others.globalSound", config::isBoolean, config::getBoolean);
-        this.saveOnChestClose = loadValue("others.saveOnChestClose", config::isBoolean, config::getBoolean);
     }
 
     public String getLocale() {
@@ -182,10 +180,6 @@ public class Configuration {
 
     public boolean isGlobalSound() {
         return this.globalSound;
-    }
-
-    public boolean isSaveOnChestClose() {
-        return this.saveOnChestClose;
     }
 
     private <T> T loadValue(String key, Predicate<String> checker, Function<String, T> getter) throws ConfigLoadingException {

--- a/plugin/src/main/java/fr/utarwyn/endercontainers/enderchest/EnderChestManager.java
+++ b/plugin/src/main/java/fr/utarwyn/endercontainers/enderchest/EnderChestManager.java
@@ -98,6 +98,15 @@ public class EnderChestManager extends AbstractManager {
     }
 
     /**
+     * Get the all context of loaded players.
+     *
+     * @return context map of all players
+     */
+    public Map<UUID, PlayerContext> getContextMap() {
+        return contextMap;
+    }
+
+    /**
      * Check if the context of a specific player is unused at a given time.
      * All chests of this context must not have viewer in their container.
      *

--- a/plugin/src/main/java/fr/utarwyn/endercontainers/enderchest/EnderChestManager.java
+++ b/plugin/src/main/java/fr/utarwyn/endercontainers/enderchest/EnderChestManager.java
@@ -11,10 +11,7 @@ import fr.utarwyn.endercontainers.enderchest.listener.EnderChestListener;
 import fr.utarwyn.endercontainers.inventory.InventoryManager;
 import org.bukkit.entity.Player;
 
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
@@ -64,7 +61,7 @@ public class EnderChestManager extends AbstractManager {
 
         // Save and unload all data
         this.loadingContexts.clear();
-        this.contextMap.values().forEach(PlayerContext::save);
+        this.contextMap.values().forEach(pc -> pc.save(Collections.emptySet()));
         this.contextMap.clear();
     }
 

--- a/plugin/src/main/java/fr/utarwyn/endercontainers/enderchest/context/SaveTask.java
+++ b/plugin/src/main/java/fr/utarwyn/endercontainers/enderchest/context/SaveTask.java
@@ -1,5 +1,9 @@
 package fr.utarwyn.endercontainers.enderchest.context;
 
+import fr.utarwyn.endercontainers.enderchest.EnderChest;
+
+import java.util.Set;
+
 /**
  * Represents the task which saves in a persistant storage all data
  * of the context of a specific player.
@@ -15,12 +19,18 @@ public class SaveTask implements Runnable {
     private final PlayerContext context;
 
     /**
+     * Set of used enderchests
+     */
+    private final Set<EnderChest> usedChests;
+
+    /**
      * Construct a new saving task.
      *
      * @param context the player context to save
      */
     public SaveTask(PlayerContext context) {
         this.context = context;
+        this.usedChests = context.preSave();
     }
 
     /**
@@ -28,7 +38,7 @@ public class SaveTask implements Runnable {
      */
     @Override
     public void run() {
-        this.context.save();
+        this.context.save(this.usedChests);
     }
 
 }

--- a/plugin/src/main/java/fr/utarwyn/endercontainers/enderchest/listener/EnderChestInventoryListener.java
+++ b/plugin/src/main/java/fr/utarwyn/endercontainers/enderchest/listener/EnderChestInventoryListener.java
@@ -4,7 +4,6 @@ import fr.utarwyn.endercontainers.Managers;
 import fr.utarwyn.endercontainers.compatibility.CompatibilityHelper;
 import fr.utarwyn.endercontainers.configuration.Files;
 import fr.utarwyn.endercontainers.enderchest.EnderChestManager;
-import fr.utarwyn.endercontainers.enderchest.VanillaEnderChest;
 import fr.utarwyn.endercontainers.inventory.EnderChestInventory;
 import fr.utarwyn.endercontainers.inventory.InventoryManager;
 import org.bukkit.Sound;
@@ -18,8 +17,6 @@ import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
-
-import java.util.Optional;
 
 /**
  * Intercepts events about chest inventories.
@@ -78,19 +75,6 @@ public class EnderChestInventoryListener implements Listener {
 
         // Play the closing sound when we use the default enderchest!
         if (this.isEnderChestInventory(event.getInventory())) {
-            Optional<VanillaEnderChest> vanilla = this.manager.getVanillaEnderchestUsedBy(player);
-
-            // When closing the default enderchest ...
-            if (vanilla.isPresent()) {
-                Player ownerObj = vanilla.get().getOwnerAsPlayer();
-
-                // ... save and delete the context from memory if the player is offline.
-                if (!ownerObj.equals(player) && !ownerObj.isOnline()) {
-                    this.manager.savePlayerContext(vanilla.get().getOwner(), true);
-                    ownerObj.saveData();
-                }
-            }
-
             // Play the closing sound
             Sound sound = CompatibilityHelper.searchSound("CHEST_CLOSE", "BLOCK_CHEST_CLOSE");
             if (Files.getConfiguration().isGlobalSound()) {

--- a/plugin/src/main/java/fr/utarwyn/endercontainers/enderchest/listener/EnderChestListener.java
+++ b/plugin/src/main/java/fr/utarwyn/endercontainers/enderchest/listener/EnderChestListener.java
@@ -16,7 +16,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
-import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.world.WorldSaveEvent;
 
 import java.util.Iterator;
@@ -122,20 +121,6 @@ public class EnderChestListener implements Listener {
                 }
             }
         }
-    }
-
-    /**
-     * Method called when a player quits the server
-     *
-     * @param event The quit event
-     */
-    @EventHandler
-    public void onPlayerQuit(PlayerQuitEvent event) {
-        UUID owner = event.getPlayer().getUniqueId();
-
-        // Clear all the player data from memory
-        boolean unused = this.manager.isContextUnused(owner);
-        this.manager.savePlayerContext(owner, unused);
     }
 
 }

--- a/plugin/src/main/java/fr/utarwyn/endercontainers/inventory/EnderChestInventory.java
+++ b/plugin/src/main/java/fr/utarwyn/endercontainers/inventory/EnderChestInventory.java
@@ -1,14 +1,11 @@
 package fr.utarwyn.endercontainers.inventory;
 
 import com.google.common.base.Preconditions;
-import fr.utarwyn.endercontainers.Managers;
 import fr.utarwyn.endercontainers.compatibility.CompatibilityHelper;
 import fr.utarwyn.endercontainers.configuration.Files;
 import fr.utarwyn.endercontainers.configuration.LocaleKey;
 import fr.utarwyn.endercontainers.enderchest.EnderChest;
-import fr.utarwyn.endercontainers.enderchest.EnderChestManager;
 import fr.utarwyn.endercontainers.util.uuid.UUIDFetcher;
-import org.bukkit.Bukkit;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -117,15 +114,6 @@ public class EnderChestInventory extends AbstractInventoryHolder {
      */
     @Override
     public void onClose(Player player) {
-        // Save and delete the player context if the owner of the chest is offline
-        Player owner = Bukkit.getPlayer(this.chest.getOwner());
-        boolean offlineOwner = owner == null || !owner.isOnline();
-
-        // Save chest inventory if owner is offline or forced by the configuration (experimental)
-        if (offlineOwner || Files.getConfiguration().isSaveOnChestClose()) {
-            Managers.get(EnderChestManager.class).savePlayerContext(this.chest.getOwner(), offlineOwner);
-        }
-
         // Play the closing sound
         Sound sound = CompatibilityHelper.searchSound("CHEST_CLOSE", "BLOCK_CHEST_CLOSE");
         if (Files.getConfiguration().isGlobalSound()) {

--- a/plugin/src/main/resources/config.yml
+++ b/plugin/src/main/resources/config.yml
@@ -69,7 +69,3 @@ others:
 
   # Use a global sound when a player opens/closes an enderchest
   globalSound: true
-
-  # Save enderchests on close. Beware! This could be very resource intensive.
-  # Enable this ONLY if you have issues with the normal saving system.
-  saveOnChestClose: false

--- a/plugin/src/test/java/fr/utarwyn/endercontainers/configuration/ConfigurationTest.java
+++ b/plugin/src/test/java/fr/utarwyn/endercontainers/configuration/ConfigurationTest.java
@@ -33,7 +33,6 @@ public class ConfigurationTest {
         assertThat(config.getMysqlSslKeystorePassword()).isNull();
         assertThat(config.getMysqlSslTrustKeystoreFile()).isNull();
         assertThat(config.getMysqlSslTrustKeystorePassword()).isNull();
-        assertThat(config.isSaveOnChestClose()).isFalse();
     }
 
     @Test

--- a/plugin/src/test/java/fr/utarwyn/endercontainers/enderchest/EnderChestManagerTest.java
+++ b/plugin/src/test/java/fr/utarwyn/endercontainers/enderchest/EnderChestManagerTest.java
@@ -70,7 +70,7 @@ public class EnderChestManagerTest {
 
         this.manager.unload();
 
-        verify(context).save();
+        verify(context).save(any());
         verify(inventoryManager).closeAll();
         assertThat(this.manager.contextMap).isEmpty();
     }

--- a/plugin/src/test/java/fr/utarwyn/endercontainers/enderchest/context/PlayerContextTest.java
+++ b/plugin/src/test/java/fr/utarwyn/endercontainers/enderchest/context/PlayerContextTest.java
@@ -163,7 +163,7 @@ public class PlayerContextTest {
 
     @Test
     public void save() {
-        this.context.save();
+        this.context.save(Collections.emptySet());
         verify(this.playerData).saveContext(any());
     }
 

--- a/plugin/src/test/java/fr/utarwyn/endercontainers/enderchest/context/SaveTaskTest.java
+++ b/plugin/src/test/java/fr/utarwyn/endercontainers/enderchest/context/SaveTaskTest.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -24,7 +25,7 @@ public class SaveTaskTest {
     @Test
     public void run() {
         this.task.run();
-        verify(this.context).save();
+        verify(this.context).save(any());
     }
 
 }

--- a/plugin/src/test/java/fr/utarwyn/endercontainers/enderchest/listener/EnderChestInventoryListenerTest.java
+++ b/plugin/src/test/java/fr/utarwyn/endercontainers/enderchest/listener/EnderChestInventoryListenerTest.java
@@ -1,11 +1,9 @@
 package fr.utarwyn.endercontainers.enderchest.listener;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Sets;
 import fr.utarwyn.endercontainers.TestHelper;
 import fr.utarwyn.endercontainers.TestInitializationException;
 import fr.utarwyn.endercontainers.enderchest.EnderChestManager;
-import fr.utarwyn.endercontainers.enderchest.VanillaEnderChest;
 import fr.utarwyn.endercontainers.inventory.EnderChestInventory;
 import fr.utarwyn.endercontainers.inventory.InventoryManager;
 import org.bukkit.*;
@@ -23,8 +21,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -177,37 +173,6 @@ public class EnderChestInventoryListenerTest {
     }
 
     @Test
-    public void inventoryCloseSaveOfflineVanillaChest() {
-        when(this.inventory.getType()).thenReturn(InventoryType.ENDER_CHEST);
-
-        Player player2 = mock(Player.class);
-        UUID player2Identifier = UUID.randomUUID();
-        VanillaEnderChest chest = mock(VanillaEnderChest.class);
-        InventoryCloseEvent event = new InventoryCloseEvent(this.inventoryView);
-
-        when(player2.getUniqueId()).thenReturn(player2Identifier);
-        when(this.manager.getVanillaEnderchestUsedBy(this.player)).thenReturn(Optional.of(chest));
-
-        // do not save if the viewer is the owner of the chest
-        when(chest.getOwnerAsPlayer()).thenReturn(this.player);
-        this.listener.onInventoryClose(event);
-        verify(this.manager, never()).savePlayerContext(player2.getUniqueId(), true);
-
-        // do not save if the player is online
-        when(chest.getOwnerAsPlayer()).thenReturn(player2);
-        when(chest.getOwner()).thenReturn(player2Identifier);
-        when(player2.isOnline()).thenReturn(true);
-        this.listener.onInventoryClose(event);
-        verify(this.manager, never()).savePlayerContext(player2.getUniqueId(), true);
-
-        // save the chest (and the player data) if the player is not the viewer and its offline
-        when(player2.isOnline()).thenReturn(false);
-        this.listener.onInventoryClose(event);
-        verify(this.manager).savePlayerContext(player2.getUniqueId(), true);
-        verify(player2).saveData();
-    }
-
-    @Test
     public void inventoryCloseGlobalSound() {
         when(this.inventory.getType()).thenReturn(InventoryType.ENDER_CHEST);
         this.listener.onInventoryClose(new InventoryCloseEvent(this.inventoryView));
@@ -241,7 +206,6 @@ public class EnderChestInventoryListenerTest {
 
         // try with an enderchest managed by the plugin -> no sound (integrated in the inventory system)
         when(event.getInventory().getType()).thenReturn(InventoryType.ENDER_CHEST);
-        when(this.manager.getVanillaEnderchestUsedBy(this.player)).thenReturn(Optional.empty());
         this.listener.onInventoryClose(event);
         verify(this.player, never()).playSound(any(Location.class), any(Sound.class), anyFloat(), anyFloat());
     }

--- a/plugin/src/test/java/fr/utarwyn/endercontainers/enderchest/listener/EnderChestListenerTest.java
+++ b/plugin/src/test/java/fr/utarwyn/endercontainers/enderchest/listener/EnderChestListenerTest.java
@@ -172,20 +172,6 @@ public class EnderChestListenerTest {
         assertThat(contextMap).isEmpty();
     }
 
-    @Test
-    public void playerLeaveSaveContext() {
-        PlayerQuitEvent event = new PlayerQuitEvent(this.player, "");
-
-        // By default, we have to save the context but not delete it
-        this.listener.onPlayerQuit(event);
-        verify(this.manager).savePlayerContext(this.player.getUniqueId(), false);
-
-        // With an unused context, we also have to delete the context
-        when(this.manager.isContextUnused(this.player.getUniqueId())).thenReturn(true);
-        this.listener.onPlayerQuit(event);
-        verify(this.manager).savePlayerContext(this.player.getUniqueId(), true);
-    }
-
     private PlayerInteractEvent createInteractEvent(Action action) {
         return new PlayerInteractEvent(this.player, action, null, this.block, BlockFace.NORTH);
     }

--- a/plugin/src/test/java/fr/utarwyn/endercontainers/inventory/EnderChestInventoryTest.java
+++ b/plugin/src/test/java/fr/utarwyn/endercontainers/inventory/EnderChestInventoryTest.java
@@ -129,18 +129,6 @@ public class EnderChestInventoryTest {
         // do not save if the owner is connected
         this.inventory.onClose(viewer);
         verify(manager, never()).savePlayerContext(any(), eq(true));
-
-        // save if forced by the configuration
-        TestHelper.overrideConfigurationValue("saveOnChestClose", true);
-        this.inventory.onClose(viewer);
-        verify(manager).savePlayerContext(this.chest.getOwner(), false);
-        TestHelper.overrideConfigurationValue("saveOnChestClose", false);
-
-        // save if owner not connected
-        UUID offline = UUID.fromString("62dcb385-f2ac-472f-9d88-a0cc0d957082");
-        when(this.chest.getOwner()).thenReturn(offline);
-        this.inventory.onClose(viewer);
-        verify(manager).savePlayerContext(this.chest.getOwner(), true);
     }
 
     @Test


### PR DESCRIPTION
## Description
- Modified the code to save Ender Chests when saving the world.
- By default, Ender Chests are only saved when a player logs out (unless the option to save when closing the chest is enabled).
- Since Ender Chests are not saved when the world is saved, their contents can be rolled back to the state of the last logged out player in the event of a server crash.
- This makes it possible to cause item loss by crashing the server with items in the chest, or item duplication by logging out with items in the chest.

## Changes
- Modified the code to save Ender Chests when saving the world.

## Related Issues
Resolves #130 

## Checklist
<!-- After posting your issue, please check the boxes below if they apply -->
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
