### PR TITLE
TempFix | minecraft version 1.21+ error 

### DIFF
--- a/plugin/src/main/java/fr/utarwyn/endercontainers/compatibility/ServerVersion.java
+++ b/plugin/src/main/java/fr/utarwyn/endercontainers/compatibility/ServerVersion.java
@@ -10,6 +10,7 @@ import org.bukkit.Bukkit;
  */
 public enum ServerVersion {
 
+    V1_21,
     V1_20,
     V1_19_R3,
     V1_19_R2,
@@ -44,7 +45,8 @@ public enum ServerVersion {
     }
 
     public static ServerVersion get() {
-        return currentVersion;
+        return currentVersion != null ? currentVersion : V1_21; //
+
     }
 
     public static String getBukkitVersion() {


### PR DESCRIPTION
Since 1.21, bukkit doesn't return version number under `org.bukkit.craftbukkit`, changed so it selects a default version if currentVersion is null, allowing for the plugin usage in newer versions.